### PR TITLE
Update README to follow the latest nextpnr-ice40 build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ cd ..
 
 git clone https://github.com/YosysHQ/nextpnr
 cd nextpnr
-    cmake . -DARCH=ice40
-    make -j$(nproc)
+    git submodule update --init --recursive
+    mkdir -p build && cd build
+    cmake .. -DARCH=ice40
+    make
     sudo make install
-cd ..
+cd ../..
 
 git clone https://github.com/YosysHQ/yosys.git
 cd yosys


### PR DESCRIPTION
The `nextpnr` repository has changed the way the tool is built from source. This incorporates the new instructions from the README file at https://github.com/YosysHQ/nextpnr