### PR TITLE
Fix wire declaration issue in nonblock/nb2

### DIFF
--- a/nonblock/nb2/top_tb.v
+++ b/nonblock/nb2/top_tb.v
@@ -6,6 +6,8 @@ module tb();
     reg [7:0]   a;
     reg [7:0]   b;
 
+    wire [7:0]  sum;
+
     initial begin
         $dumpfile("top_tb.vcd");
         $dumpvars;
@@ -30,7 +32,6 @@ module tb();
     // The assignment below gets scheduled in the active queue as a result
     // of the nonblocking assignmnet into b.
 
-    wire [7:0] sum;
     assign sum = b+1;
 
 endmodule


### PR DESCRIPTION
Wire sum delared at line 33 and used at line 13. This causes iverilog to complain about it. Move declaration at the top of file to fix it.

```
iverilog -o top_tb.vvp top_tb.v
top_tb.v:13: error: Unable to bind wire/reg/memory `sum' in `tb'
1 error(s) during elaboration.
make: *** [Makefile:13: top_tb.vvp] Error 1
```
iverilog complains with the error message above.